### PR TITLE
Bug fix on repeated lvgl downloads

### DIFF
--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -95,7 +95,7 @@ UNPACK ?= unzip -o
 
 LVGL_UNPACKDIR =  $(WD)/$(LVGL_UNPACKNAME)
 
-ifneq($(wildcard $(LVGL_UNPACKDIR)/CMakeLists.txt),)
+ifneq ($(wildcard $(LVGL_UNPACKNAME)/CMakeLists.txt),)
 
 $(LVGL_TARBALL):
 	$(Q) echo "Downloading: lvgl $(LVGL_TARBALL)"
@@ -108,7 +108,7 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
 #Download and unpack tarball if no git repo found
-	ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
+ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 	context:: $(LVGL_UNPACKNAME)
 
 	distclean::


### PR DESCRIPTION
While building lvgl for nuttx, each time lvgl is downloaded from the source repository. The Changes includes:

The Make file checks if lvgl Make files are already present to prevent re-download. Summary

While building LVGL #include<lvgl/lvgl.h> the make build system downloads every time from the repository even when the file is present. Tweaked the build to skip downloading again if LVGL makefiles are already Present.

Impact

When building using "make clean" and "make", everytime lvgl is downloaded irrespective of whether the source is present.

Testing

Unit Tests on With lvgl Source and without lvgl source was done.

## Summary

## Impact

## Testing

